### PR TITLE
Feature: update layers on drop

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "niivue-desktop",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "niivue-desktop",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@emotion/react": "^11.11.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,7 +5,7 @@
   "description": "A medical image viewer with a focus on neuroimaging",
   "main": "src/electron/index.js",
   "scripts": {
-    "dev": "concurrently --kill-others \"npm run dev:ui\" \"electron-forge start -- --dev /Users/taylor/data/gui/bet/T1.nii.gz\"",
+    "dev": "concurrently --kill-others \"npm run dev:ui\" \"electron-forge start -- --dev\"",
     "dev:ui": "vite",
     "build:ui": "vite build",
     "start": "npm run build:ui && electron-forge start",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "niivue-desktop",
   "productName": "NiiVue",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A medical image viewer with a focus on neuroimaging",
   "main": "src/electron/index.js",
   "scripts": {

--- a/desktop/src/ui/App.jsx
+++ b/desktop/src/ui/App.jsx
@@ -28,6 +28,10 @@ const sliceTypes = {
 function App() {
   // create a new Niivue object
   const nv = useContext(NV)
+  nv.onImageLoaded = (volume) => {
+    console.log('image loaded', volume)
+    handleDrop()
+  }
   
   // get the list of colormap names
   const colormapNames = nv.colormaps(true) // sorted by name
@@ -196,6 +200,22 @@ function App() {
     })
     console.log(newImages)
     setImages(newImages)
+  }
+
+  function handleDrop(){
+    let volumes = nv.volumes
+    let newImages = volumes.map((volume, index) => {
+      return {
+        url: volume.url,
+        name: volume.name,
+        index: index,
+        id: volume.id,
+        color: volume.colormap,
+        active: index === activeImage
+      }
+    })
+    console.log(newImages)
+    setImages(newImages) 
   }
 
   const handleRemove = useCallback((index) => {


### PR DESCRIPTION
closes #20 

User can drop an image on the canvas to load, or hold shift while dropping to append image to layers list rather than replacing all images.